### PR TITLE
Improve the speed of the pack_pcm_data function

### DIFF
--- a/chippy/synthesizer.py
+++ b/chippy/synthesizer.py
@@ -116,11 +116,14 @@ class Synthesizer:
 
     # The following function packs lists of numeric representation into raw bytes:
 
-    def pack_pcm_data(self, wave_generator, length):
+    def pack_pcm_data(self, wave_generator, length, fast_int=int):
         # Return a bytestring containing the raw waveform data.
+        fast_amplitude_scale = self._amplitude_scale
+
         num_bytes = int(self.framerate * length)
-        return array.array('h', [int(self._amplitude_scale * next(wave_generator))
-                                 for _ in range(num_bytes)]).tobytes()
+        wave_slices = itertools.islice(wave_generator, num_bytes)
+        waves = (fast_int(fast_amplitude_scale * elem) for elem in wave_slices)
+        return array.array('h', waves).tobytes()
 
     def wave_data(self, wave_generator, length, riff_header=True):
         num_bytes = int(self.framerate * length)


### PR DESCRIPTION
Hi!

I am using your tool for generating test files for my project (https://github.com/PCManticore/foo_rpc).
Unfortunately, I hit a problem when trying to generate longer wav files. For a 120 seconds length, the time to generate 5 test files increased dramatically, which determined me to find the culprit and maybe
try to optimize it a bit.

From what I noticed, the problem seems to be with pack_pcm_data function. The problem is that currently is doing thrashy function calls. For example, generating a Wav file with the length 120 will imply 5292000 number of bytes, using the default settings, which means:
- 5 million next() builtin function calls
- 5 million int() function calls
- a list of 5 million elemens, passed to array.array

Things definitely can be improved and here is what I did in my patch:
- instead of calling 5 million times the next() builtin, we use the itertools module for retrieving those items, with itertools.islice
- instead of having that huge list, we just build a lazy generator comprehension of those values, passed then to array.array, which happily accepts it.
- instead of doing milions of lookups in the instance's dictionary for finding the amplitude scale, we retrieve it and use it locally.
- we use the same trick as above for optimizing the lookup of the int() builtin.

Unfortunately, I don't think there is anything to do for the int() calls, it would have been nice to improve that as well. Also, it would have been nice to provide some tests, to see that my change is actually working, but since there are no tests anyway for the project, I didn't bother to try something, hope that is okay for you.

My tests involved the following script:

```
import chippy
import timeit

synth = chippy.Synthesizer(framerate=44100)

f = timeit.Timer("synth.sine_pcm(length=120)", "from __main__ import synth").timeit(10)
print(f)
```

with the results:
- without the patch: 28.578
- with the patch: 23.951

That is a 16.20 % improvement, which I think is a bit nice. Increasing the number of repetitions should yield a similar improvement.

Anyway, thank you for the tool and let me know if this makes sense to you.
